### PR TITLE
all: spelling: Fix typos/misspells in various files

### DIFF
--- a/src/arch/xtensa/drivers/timer.c
+++ b/src/arch/xtensa/drivers/timer.c
@@ -82,7 +82,7 @@ uint64_t arch_timer_get_system(struct timer *timer)
 
 	/* check and see whether 32bit IRQ is pending for timer */
 	if (arch_interrupt_get_status() & (1 << timer->irq) && ccompare == 1) {
-		/* yes, overflow has occured but handler has not run */
+		/* yes, overflow has occurred but handler has not run */
 		high = timer->hitime + 1;
 	} else {
 		/* no overflow */

--- a/src/arch/xtensa/hal/mpu.c
+++ b/src/arch/xtensa/hal/mpu.c
@@ -527,7 +527,7 @@ static int encode_access_rights(int cattr)
 
 /*
  * returns the largest value rv, such that for every index < rv,
- * entrys[index].vStartAddress < first.
+ * entries[index].vStartAddress < first.
  *
  * Assumes an ordered entry array (even disabled entries must be ordered).
  * value returned is in the range [0, XCHAL_MPU_ENTRIES].

--- a/src/arch/xtensa/include/xtensa/core-macros.h
+++ b/src/arch/xtensa/include/xtensa/core-macros.h
@@ -369,7 +369,7 @@
 # define XTHAL_SET_CCOMPARE(n,v)	do {/*nothing*/} while(0)
 #endif
 
-/*  New functions added to accomodate XEA3 and allow deprecation of older
+/*  New functions added to accommodate XEA3 and allow deprecation of older
     functions. For this release they just map to the older ones.  */
 
 /*  Enables the specified interrupt.  */

--- a/src/arch/xtensa/include/xtensa/trax.h
+++ b/src/arch/xtensa/include/xtensa/trax.h
@@ -332,7 +332,7 @@ int trax_set_pcstop (trax_context *context, int index, unsigned long startaddres
  * index	: container of information about the number of stop triggers
  * startaddress	: container of start range of stop trigger
  * endaddress	: container of end range of stop trigger
- * flags	: container of information whcih indicates whether the
+ * flags	: container of information which indicates whether the
  * 		  pc stop range is inverted or not.
  *
  * returns      : 0 if successful, -1 if unsuccessful

--- a/src/arch/xtensa/include/xtensa/xdm-regs.h
+++ b/src/arch/xtensa/include/xtensa/xdm-regs.h
@@ -211,8 +211,8 @@
 /***********  Bit definitions within some of the above registers  ***********/
 #define OCD_ID_LSDDRP			0x01000000
 #define OCD_ID_LSDDRP_SHIFT			24
-#define OCD_ID_ENDIANESS		0x00000001
-#define OCD_ID_ENDIANESS_SHIFT			 0
+#define OCD_ID_ENDIANNESS		0x00000001
+#define OCD_ID_ENDIANNESS_SHIFT		 0
 #define OCD_ID_PSO			0x0000000C
 #define OCD_ID_PSO_SHIFT			 2
 #define OCD_ID_TRACEPORT		0x00000080

--- a/src/arch/xtensa/include/xtensa/xmon.h
+++ b/src/arch/xtensa/include/xtensa/xmon.h
@@ -123,12 +123,12 @@ _xmon_log(char app_log_en, char app_trace_en,
  * Receive remote packet bytes from GDB
  * wait:    If the function would block waiting for more 
  *          characters from gdb, wait=0 instructs it to 
- *          return 0 immediatelly. Otherwise, if wait=1, 
+ *          return 0 immediately. Otherwise, if wait=1,
  *          the function may or may not wait for GDB. 
  *          NOTE: Current XMON version supports single char
  *          input only (return value is 1 always)
  * buf:     Pointer to the buffer for the received data.
- * Returns: 0  - no data avaiable, 
+ * Returns: 0  - no data available,
             >0 - length of received array in buf.
  */
 extern int 

--- a/src/arch/xtensa/main-entry.S
+++ b/src/arch/xtensa/main-entry.S
@@ -8,7 +8,7 @@
 /*
  * Entry point from boot loader.
  * Fix link address of this entry to SOF_TEXT_START so that
- * it is easy for boot loader to jump to the baseFW becasue
+ * it is easy for boot loader to jump to the baseFW because
  * the boot loader and baseFW are in different elf file.
  */
 

--- a/src/platform/apollolake/lib/power_down.S
+++ b/src/platform/apollolake/lib/power_down.S
@@ -127,7 +127,7 @@ _PD_RELEASE_VNN:
 
 _PD_SEND_IPC:
 	// Send IPC to host informing of PD completion - Clear BUSY bit by
-	// writting IPC_DIPCT_BUSY to IPC_DIPCT
+	// writing IPC_DIPCT_BUSY to IPC_DIPCT
 	l32i temp_reg1, host_base, IPC_DIPCT
 	movi temp_reg2, IPC_DIPCT_BUSY
 	or temp_reg1, temp_reg1, temp_reg2


### PR DESCRIPTION
Fix some typos in order to make the output of checkpatch less cluttered. 